### PR TITLE
Fetch version if already exists

### DIFF
--- a/lib/fastlane/plugin/jira_set_fix_version/actions/jira_set_fix_version_action.rb
+++ b/lib/fastlane/plugin/jira_set_fix_version/actions/jira_set_fix_version_action.rb
@@ -44,7 +44,8 @@ module Fastlane
         end
 
         version = project.versions.find { |version| version.name == name }
-        version = client.Version.build if version.nil?        version.save!({
+        version = client.Version.build if version.nil?
+        version.save!({
           "description" => description,
           "name" => name,
           "archived" => archived,

--- a/lib/fastlane/plugin/jira_set_fix_version/actions/jira_set_fix_version_action.rb
+++ b/lib/fastlane/plugin/jira_set_fix_version/actions/jira_set_fix_version_action.rb
@@ -43,8 +43,8 @@ module Fastlane
           start_date = Date.today.to_s
         end
 
-        version = client.Version.build
-        version.save!({
+        version = project.versions.find { |version| version.name == name }
+        version = client.Version.build if version.nil?        version.save!({
           "description" => description,
           "name" => name,
           "archived" => archived,

--- a/lib/fastlane/plugin/jira_set_fix_version/version.rb
+++ b/lib/fastlane/plugin/jira_set_fix_version/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module JiraSetFixVersion
-    VERSION = "1.0.0"
+    VERSION = "1.0.1"
   end
 end


### PR DESCRIPTION
Instead of always creating a new version, check for it if it exists, if not create it.

This pull request to fix issue #1 